### PR TITLE
Add Known Types To SlimSerializer. 

### DIFF
--- a/Serializers/SlimSerializer.cs
+++ b/Serializers/SlimSerializer.cs
@@ -1,6 +1,9 @@
 ﻿using System.IO;
-using NFX.Serialization.Slim;
 using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Linq;
+using NFX.Serialization.Slim;
 
 namespace SerializerTests.Serializers
 {
@@ -13,8 +16,25 @@ namespace SerializerTests.Serializers
        
         public SlimSerializer(Func<int, T> testData)
         { 
-             base.CreateNTestData = testData;
-             FormatterFactory = () => new SlimSerializer();
+            base.CreateNTestData = testData;
+            FormatterFactory = () =>
+            {
+              var types = Assembly.GetExecutingAssembly()
+                                  .GetTypes()
+                                  .Where(t => t.IsClass && t.Namespace == "SerializerTests.TypesToSerialize")
+                                  .SelectMany(t => makeVariations(t));
+
+              var result = new SlimSerializer( types );
+              result.TypeMode = TypeRegistryMode.Batch;
+              return result;
+            };
+        }
+
+        private IEnumerable<Type> makeVariations(Type t)
+        {
+          yield return t;
+          yield return t.MakeArrayType();
+          yield return typeof(List<>).MakeGenericType(t);
         }
 
         protected override T Deserialize(Stream stream)

--- a/Serializers/SlimSerializer.cs
+++ b/Serializers/SlimSerializer.cs
@@ -25,7 +25,8 @@ namespace SerializerTests.Serializers
                                   .SelectMany(t => makeVariations(t));
 
               var result = new SlimSerializer( types );
-              result.TypeMode = TypeRegistryMode.Batch;
+              //Enable Batch mode for streaming messages, in that case the deserializing serializer has to be a different instance
+              //result.TypeMode = TypeRegistryMode.Batch;
               return result;
             };
         }


### PR DESCRIPTION
If I am not mistaken the Wire serializer can benefit from the similar approach.

Also, the very beneficial test case would have been:
 create an object and serilize it many times into stream, not 1 huge object, but 1 small i.e. with 5-10 fields  (like a business message) and write it to stream 50,000 times etc..

This is a typical case used in networking/service apps.

Slim has special optimization for it called Batching - I have added a comment for that



