### PR TITLE
Add Apex.Serialization

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -98,6 +98,7 @@ namespace SerializerTests
 
             SerializersToTest = new List<ISerializeDeserializeTester>
             {
+                new ApexSerializer<BookShelf>(Data, Touch),
 #if NETCOREAPP3_0
                 new NetCoreJsonSerializer<NetCorePropertyBookShelf>(DataNetCore, Touch),
                 new SimdJsonSharpSerializer<BookShelf>(Data, Touch),
@@ -139,6 +140,11 @@ namespace SerializerTests
 
             StartupSerializersToTest = new List<ISerializeDeserializeTester>
             {
+                new ApexSerializer<BookShelf>(Data, null),
+                new ApexSerializer<BookShelf1>(Data1, null),
+                new ApexSerializer<BookShelf2>(Data2, null),
+                new ApexSerializer<LargeBookShelf>(DataLarge, null),
+
                 new ServiceStack<BookShelf>(Data, null),
                 new ServiceStack<BookShelf1>(Data1, null),
                 new ServiceStack<BookShelf2>(Data2, null),
@@ -230,12 +236,13 @@ namespace SerializerTests
 	            new Utf8JsonSerializer<BookShelf1>(Data1, null),
 	            new Utf8JsonSerializer<BookShelf2>(Data2, null),
 	            new Utf8JsonSerializer<LargeBookShelf>(DataLarge, null),
-			};
+            };
 
             StartupSerializersToTest = StartupSerializersToTest.Where(filter).ToList();
 
             SerializersObjectReferencesToTest = new List<ISerializeDeserializeTester>
             {
+                new ApexSerializer<ReferenceBookShelf>(DataReferenceBookShelf, null),
                 // FlatBuffer does not support object references
                 new MessagePackSharp<ReferenceBookShelf>(DataReferenceBookShelf, null),
                 new GroBuf<ReferenceBookShelf>(DataReferenceBookShelf, null),
@@ -264,7 +271,7 @@ namespace SerializerTests
                 new MsgPack_Cli<ReferenceBookShelf>(DataReferenceBookShelf, null),
                 new BinaryFormatter<ReferenceBookShelf>(DataReferenceBookShelf, null),
 				new Utf8JsonSerializer<ReferenceBookShelf>(DataReferenceBookShelf, null)
-			};
+            };
 
             SerializersObjectReferencesToTest = SerializersObjectReferencesToTest.Where(filter).ToList();
         }

--- a/SerializerTests.csproj
+++ b/SerializerTests.csproj
@@ -40,6 +40,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Apex.Serialization" Version="1.0.0" />
     <PackageReference Include="Azos" Version="1.0.508" />
     <PackageReference Include="fastJSON" Version="2.2.4" />
     <PackageReference Include="GroBuf" Version="1.4.8" />

--- a/Serializers/Apex.cs
+++ b/Serializers/Apex.cs
@@ -1,0 +1,29 @@
+﻿using Apex.Serialization;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace SerializerTests.Serializers
+{
+    public sealed class ApexSerializer<T> : TestBase<T, IBinary> where T : class
+    {
+        public ApexSerializer(Func<int, T> testData, Action<T> dataToucher) : base(testData, dataToucher)
+        {
+            FormatterFactory = () => Binary.Create(new Settings { SerializationMode = RefTracking ? Mode.Graph : Mode.Tree });
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        protected override void Serialize(T obj, Stream stream)
+        {
+            Formatter.Write(obj, stream);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        protected override T Deserialize(Stream stream)
+        {
+            return Formatter.Read<T>(stream);
+        }
+    }
+}


### PR DESCRIPTION
Compared to protobuf-net:

| Name | Items | Serialization time in seconds | Deserialization time in seconds | Size in bytes |
|---|---|---|---|---|
| `ApexSerializer<BookShelf>`	| 1000000	| 0.015	| 0.132	| 30777851 |
| `Protobuf_net<BookShelf>`  	| 1000000	| 0.100	| 0.554	| 18872408 |

Apex.Serialization also supports both object trees/graphs, as well as polymorphic types, private/readonly fields, delegates, etc.