### PR TITLE
Update Apex.Serialization to 1.3.0

### DIFF
--- a/SerializerTests.csproj
+++ b/SerializerTests.csproj
@@ -40,7 +40,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Apex.Serialization" Version="1.0.0" />
+    <PackageReference Include="Apex.Serialization" Version="1.3.0" />
     <PackageReference Include="Azos" Version="1.0.508" />
     <PackageReference Include="fastJSON" Version="2.2.4" />
     <PackageReference Include="GroBuf" Version="1.4.8" />


### PR DESCRIPTION
Improves serialization time for 1M items from 0.015 seconds to 0.0123 seconds, and deserialization time from 0.132 seconds to 0.106 seconds.  Binary size remains the same.