### PR TITLE
Add FlatSharp

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -182,6 +182,7 @@ namespace SerializerTests
                 new MessagePackSharp<BookShelf>(Data, TouchAndVerify),
                 new GroBuf<BookShelf>(Data, TouchAndVerify),
                 new FlatBuffer<BookShelf,BookShelfFlat>(Data, TouchFlat),
+                new FlatSharpTest(Data, TouchAndVerify),
 #if NET472
                 // Hyperion does not work on .NET Core 3.0  https://github.com/akkadotnet/Hyperion/issues/111
                 // new Hyperion<BookShelf>(Data, Touch),
@@ -854,6 +855,42 @@ namespace SerializerTests
                 if (optionalPayloadDataSize > 0 && data.Books[i].BookData.Length != optionalPayloadDataSize)
                 {
                     throw new InvalidOperationException($"BookData length was {data.Books[i].BookData.Length} but expected {optionalPayloadDataSize}");
+                }
+            }
+        }
+
+        void TouchAndVerify(BookShelfFlatSharp data, int nExpectedBooks, int optionalPayloadDataSize)
+        {
+            if (!VerifyAndTouch)
+            {
+                return;
+            }
+
+            string tmpTitle = null;
+            int tmpId = 0;
+
+            var books = data.Books;
+            int count = books.Count;
+            if (nExpectedBooks != count)
+            {
+                throw new InvalidOperationException($"Number of deserialized Books was {data.Books.Count} but expected {nExpectedBooks}. This Serializer seem to have lost data.");
+            }
+
+            for (int i = 0; i < count; i++)
+            {
+                var book = books[i];
+
+                tmpTitle = book.Title;
+                tmpId = book.Id;
+
+                if (tmpId != i + 1)
+                {
+                    throw new InvalidOperationException($"Book Id was {data.Books[i].Id} but exepcted {i + 1}");
+                }
+
+                if (optionalPayloadDataSize > 0 && book.BookData.Value.Length != optionalPayloadDataSize)
+                {
+                    throw new InvalidOperationException($"BookData length was {data.Books[i].BookData.Value.Length} but expected {optionalPayloadDataSize}");
                 }
             }
         }

--- a/SerializerTests.csproj
+++ b/SerializerTests.csproj
@@ -5,6 +5,7 @@
     <TargetFrameworks>net70;net60;net50;netcoreapp3.1;net48</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp3.0|AnyCPU'">
     <DefineConstants>TRACE</DefineConstants>
@@ -18,6 +19,7 @@
     <Compile Remove="packages\**" />
     <None Remove="packages\**" />
   </ItemGroup>
+    
   <ItemGroup>
     <None Remove=".gitattributes" />
     <None Remove=".gitignore" />
@@ -51,6 +53,9 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
+    <FlatSharpSchema Include="TypesToSerialize\FlatSharpBook.fbs" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Apex.Serialization" Version="4.0.3" Condition=" '$(TargetFramework)' == 'net70' OR '$(TargetFramework)' == 'net60' " />
 	<PackageReference Include="Apex.Serialization" Version="3.0.0" Condition=" '$(TargetFramework)' == 'net50' " />
     <PackageReference Include="Apex.Serialization" Version="1.3.1" Condition=" '$(TargetFramework)' == 'netcoreapp3.0' OR '$(TargetFramework)' == 'netcoreapp3.1'" />
@@ -59,6 +64,11 @@
 	<PackageReference Include="BinaryPack" Version="1.0.3" Condition=" '$(TargetFramework)' == 'net70' OR '$(TargetFramework)' == 'net60'  OR '$(TargetFramework)' == 'net50' OR '$(TargetFramework)' == 'netcoreapp3.1'" />
     <PackageReference Include="Ceras" Version="4.1.7" />
     <PackageReference Include="fastJSON" Version="2.4.0.4" />
+    <PackageReference Include="FlatSharp.Compiler" Version="7.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="FlatSharp.Runtime" Version="7.0.2" />
     <PackageReference Include="Google.Protobuf" Version="3.21.9" />
     <PackageReference Include="GroBuf" Version="1.8.1" />
     <PackageReference Include="Hyperion" Version="0.12.2" />

--- a/Serializers/FlatSharp.cs
+++ b/Serializers/FlatSharp.cs
@@ -1,0 +1,84 @@
+﻿using Azos.Data.Modeling.DataTypes;
+using Azos.Scripting;
+using FlatSharp;
+using Google.FlatBuffers;
+using SerializerTests.TypesToSerialize;
+using ServiceStack.Text;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.CompilerServices;
+
+namespace SerializerTests.Serializers
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    [SerializerType("https://github.com/jamescourtney/FlatSharp/",
+                    SerializerTypes.Binary | SerializerTypes.SupportsVersioning)]
+    class FlatSharpTest : TestBase<BookShelf, BookShelfFlatSharp, ByteBuffer>
+    {
+        private BookShelf knownBookshelf;
+        private BookShelfFlatSharp fsShelf;
+
+        public FlatSharpTest(Func<int, BookShelf> testData, Action<BookShelfFlatSharp, int, int> touchAndVerify, bool refTracking = false) : base(testData, touchAndVerify, refTracking)
+        {
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        protected override void Serialize(BookShelf obj, Stream stream)
+        {
+            this.TranslateObject(obj);
+
+            MemoryStream ms = (MemoryStream)stream;
+
+            var serializer = BookShelfFlatSharp.Serializer;
+            var shelf = this.fsShelf;
+
+            // Expand size if necessary.
+            ms.SetLength(serializer.GetMaxSize(shelf));
+
+            // Write to the underlying buffer.
+            int bytesWritten = serializer.Write(ms.GetBuffer(), shelf);
+
+            // Update the buffer to indicate how many bytes were written.
+            ms.Position = bytesWritten;
+            ms.SetLength(bytesWritten);
+        }
+
+        /// <summary>
+        /// Since FlatSharp doesn't use the common Bookshelf object, add a translation step here.
+        /// Note: since this translation process is expensive (and not part of the benchmark),
+        /// only do this once per unique BookShelf.
+        /// </summary>
+        private void TranslateObject(BookShelf obj)
+        {
+            if (this.knownBookshelf == obj)
+            {
+                return;
+            }
+
+            this.knownBookshelf = obj;
+            var books = obj.Books;
+
+            BookShelfFlatSharp bookshelf = new BookShelfFlatSharp();
+            List<BookFlatSharp> fsBooks = new List<BookFlatSharp>(books.Count);
+
+            foreach (var book in books)
+            {
+                fsBooks.Add(new BookFlatSharp { BookData = book.BookData, Id = book.Id, Title = book.Title });
+            }
+
+            bookshelf.Books = fsBooks;
+            this.fsShelf = bookshelf;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        protected override BookShelfFlatSharp Deserialize(Stream stream)
+        {
+            byte[] buffer = ((MemoryStream)stream).GetBuffer();
+            return BookShelfFlatSharp.Serializer.Parse(buffer);
+        }
+    }
+}

--- a/TypesToSerialize/FlatSharpBook.fbs
+++ b/TypesToSerialize/FlatSharpBook.fbs
@@ -1,0 +1,15 @@
+// example IDL file
+attribute "fs_serializer";
+
+namespace SerializerTests.Serializers;
+
+table BookFlatSharp {
+  Title:string;
+  Id:int;
+  BookData:[ubyte];
+}
+
+table BookShelfFlatSharp (fs_serializer:"Lazy") { // lazy parsing means you must run with -verify to actually use the parsed object
+  Books:[BookFlatSharp];
+  Secret:string;
+}


### PR DESCRIPTION
Add FlatSharp to the benchmark. Note: since FlatSharp wants to use byte arrays and not streams, I've done some creative casting with the provided stream objects to use the memory stream's underlying buffer to avoid extra copies.